### PR TITLE
kde.adoc: sentences (AsciiDoc), white space at foot

### DIFF
--- a/2022q3/kde.adoc
+++ b/2022q3/kde.adoc
@@ -16,9 +16,9 @@ The notes below describe *mostly* ports for KDE, but also include items that are
 
 The big news in the KDE ports is not directly KDE-related. Qt6 has landed, which prepares us for the next generation of Qt-based applications.
 It is now possible to have `USES=qt:6` to select the new Qt version. Some ports have been flavorized to make use of the new version.
-KDE itself is not affected: the upstream work on KDE Frameworks for Qt6 is not yet completed. Most of the KDE Frameworks
-will compile with Qt6, but that is not important for FreeBSD ports yet. With
-package:devel/qt6[] you get Qt 6.4.0, released at the end of the quarter.
+KDE itself is not affected: the upstream work on KDE Frameworks for Qt6 is not yet completed.
+Most of the KDE Frameworks will compile with Qt6, but that is not important for FreeBSD ports yet.
+With package:devel/qt6[] you get Qt 6.4.0, released at the end of the quarter.
 
 ==== KDE Stack
 
@@ -37,5 +37,3 @@ Note that KDE Plasma 5.25 has been released upstream, but is waiting on fixes el
 * package:devel/cmake[] was reorganized, so that package:devel/cmake[] is now a metaport that installs package:devel/cmake-core[] and the rest of the CMake suite. (Thanks to diizzy@) The CMake ports were also updated to version 3.24, with attendant changes in ports all over the tree.
 * package:net/qt5-network[] has improved compatibility with libressl.
 * package:x11/plasma-wayland-protocols[] was updated in advance of KDE Plasma Desktop updates in the next quarter.
-
-


### PR DESCRIPTION
<https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#paragraphs>

… encouragement to mark up sentences in this way is not explicit, however I see at least one doc person habitually doing a new line for each sentence, so I assume that it's 'the done thing'. 